### PR TITLE
Bump dep.jackson.version from 2.9.8 to 2.9.9 (#64)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <mainClass>com.wouter.dndbattle.core.Main</mainClass>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <dep.jackson.version>2.9.8</dep.jackson.version>
+        <dep.jackson.version>2.9.9</dep.jackson.version>
         <dep.commons.version>2.6</dep.commons.version>
         <dep.openhtml.version>0.0.1-RC20</dep.openhtml.version>
     </properties>


### PR DESCRIPTION
Bumps `dep.jackson.version` from 2.9.8 to 2.9.9.

Updates `jackson-core` from 2.9.8 to 2.9.9
- [Release notes](https://github.com/FasterXML/jackson-core/releases)
- [Commits](https://github.com/FasterXML/jackson-core/compare/jackson-core-2.9.8...jackson-core-2.9.9)

Updates `jackson-annotations` from 2.9.8 to 2.9.9
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `jackson-databind` from 2.9.8 to 2.9.9
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Signed-off-by: dependabot[bot] <support@dependabot.com>

**The title of your contribution**
A title of the bug you fixed or the feature you added

**Description**
A description (put some details) of the bug or feature and the way it was fixed or created.

**Extra dependencies**
A list of dependencies you had to add to create the feature or fix de bug.
Please also include the required licencing (GPL, GNU, etc.) for the dependencies.

**Possible bugs**
A list of bugs currently known with the bug fix or feature you added.
